### PR TITLE
Update evio_loop.go

### DIFF
--- a/evio_loop.go
+++ b/evio_loop.go
@@ -363,9 +363,11 @@ func serve(events Events, lns []*listener) error {
 				c := v.(*unixConn)
 				if now.After(v.Timeout()) {
 					timeoutqueue.Pop()
+					lock()
 					if _, ok := idconn[c.id]; ok && c.opening {
 						delete(idconn, c.id)
 						delete(fdconn, c.fd)
+						unlock()
 						filladdrs(c)
 						syscall.Close(c.fd)
 						if events.Opened != nil {
@@ -384,6 +386,8 @@ func serve(events Events, lns []*listener) error {
 							}
 						}
 						count++
+					} else {
+						unlock()
 					}
 				} else {
 					break


### PR DESCRIPTION
Fix the race conditions.

It was not thread safe to delete items from idconn and fdconn when checking for dial connection timeouts.