### PR TITLE
Use Receive() and Send() instead of Data()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.*
+*/*.so
+*/*.so.*
+*.bak
+*.exe
+*.log
+*.sublime-project
+*.sublime-workspace
+*.tmp
+*.txt
+*.upx
+*.vscode

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The event type has a bunch of handy events:
 - `Opened` fires when a connection has opened.
 - `Closed` fires when a connection has closed.
 - `Detach` fires when a connection has been detached using the `Detach` return action.
-- `Data` fires when the server receives new data from a connection.
+- `Receive` fires when the server receives new data from a connection.
+- `Send` fires when the server is waked up for sending data.
 - `Tick` fires immediately after the server starts and will fire again after a specified interval.
 
 ### Multiple addresses


### PR DESCRIPTION
Users have two choices:
```go
var events evio.Events{}
events.Send = func(c evio.Conn) (out []byte, action evio.Action) {
    return
}
events.Receive = func(c Conn, in []byte) (out []byte, action evio.Action) {
    return
}
```
or
```go
var events evio.Events{}
events.Data= func(c Conn, in []byte) (out []byte, action evio.Action) {
    if in == nil {
    } else {
    }
    return
}
```