### PR TITLE
evio_unix will auto close the connections, when no data is read out

### DIFF
--- a/evio_unix.go
+++ b/evio_unix.go
@@ -422,12 +422,17 @@ func loopWake(s *server, l *loop, c *conn) error {
 func loopRead(s *server, l *loop, c *conn) error {
 	var in []byte
 	n, err := syscall.Read(c.fd, l.packet)
-	if n == 0 || err != nil {
+	if err != nil {
 		if err == syscall.EAGAIN {
 			return nil
 		}
 		return loopCloseConn(s, l, c, err)
 	}
+	// if n is empty, return nil for next incoming data
+	if n == 0 {
+		return nil
+	}
+
 	in = l.packet[:n]
 	if !c.reuse {
 		in = append([]byte{}, in...)


### PR DESCRIPTION
System: MacOs Mojave,
Serve address: tcp://localhost:8081?reuseport=true
Test Code:
`
var conns []net.Conn

for count := 0; count < 10; count++ {
	conn, err := net.Dial("tcp", "localhost:8101")
	conns = append(conns, conn)

	if err != nil {
		log.Panic(err)
	}

	// time.Sleep(time.Second * time.Duration(rand.Intn(3)))
}

for index, conn := range conns {
	str := fmt.Sprintf("Hello, Evio, from conn: %d\n", index)
	conn.Write([]byte(str))
}
