### PR TITLE
Utilize map to store listeners instead of slice, enhancing performance

### DIFF
--- a/evio.go
+++ b/evio.go
@@ -55,8 +55,6 @@ type Conn interface {
 	Context() interface{}
 	// SetContext sets a user-defined context.
 	SetContext(interface{})
-	// AddrIndex is the index of server address that was passed to the Serve call.
-	AddrIndex() int
 	// LocalAddr is the connection's local socket address.
 	LocalAddr() net.Addr
 	// RemoteAddr is the connection's remote peer address.

--- a/evio.go
+++ b/evio.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -226,6 +227,47 @@ type listener struct {
 	fd      int
 	network string
 	addr    string
+}
+
+func (ln *listener) close() {
+	if ln.fd != 0 {
+		syscall.Close(ln.fd)
+	}
+	if ln.f != nil {
+		ln.f.Close()
+	}
+	if ln.ln != nil {
+		ln.ln.Close()
+	}
+	if ln.pconn != nil {
+		ln.pconn.Close()
+	}
+	if ln.network == "unix" {
+		os.RemoveAll(ln.addr)
+	}
+}
+
+// system takes the net listener and detaches it from it's parent
+// event loop, grabs the file descriptor, and makes it non-blocking.
+func (ln *listener) system() error {
+	var err error
+	switch netln := ln.ln.(type) {
+	case nil:
+		switch pconn := ln.pconn.(type) {
+		case *net.UDPConn:
+			ln.f, err = pconn.File()
+		}
+	case *net.TCPListener:
+		ln.f, err = netln.File()
+	case *net.UnixListener:
+		ln.f, err = netln.File()
+	}
+	if err != nil {
+		ln.close()
+		return err
+	}
+	ln.fd = int(ln.f.Fd())
+	return syscall.SetNonblock(ln.fd, true)
 }
 
 type addrOpts struct {

--- a/evio.go
+++ b/evio.go
@@ -179,10 +179,8 @@ func Serve(events Events, addr ...string) error {
 		} else {
 			ln.lnaddr = ln.ln.Addr()
 		}
-		if !stdlib {
-			if err := ln.system(); err != nil {
-				return err
-			}
+		if err := ln.system(); err != nil {
+			return err
 		}
 		lns = append(lns, &ln)
 	}

--- a/evio_std.go
+++ b/evio_std.go
@@ -18,19 +18,18 @@ var errClosing = errors.New("closing")
 var errCloseConns = errors.New("close conns")
 
 type stdserver struct {
-	events   Events         // user events
-	loops    []*stdloop     // all the loops
-	fdlns    map[int]*listener  // listeners map with fd as key
-	loopwg   sync.WaitGroup // loop close waitgroup
-	lnwg     sync.WaitGroup // listener close waitgroup
-	cond     *sync.Cond     // shutdown signaler
-	serr     error          // signal error
-	accepted uintptr        // accept counter
+	events   Events            // user events
+	loops    []*stdloop        // all the loops
+	fdlns    map[int]*listener // listeners map with fd as key
+	loopwg   sync.WaitGroup    // loop close waitgroup
+	lnwg     sync.WaitGroup    // listener close waitgroup
+	cond     *sync.Cond        // shutdown signaler
+	serr     error             // signal error
+	accepted uintptr           // accept counter
 }
 
 type stdudpconn struct {
-	addrIndex  int
-	sockfd     int              // socket file descriptor
+	sockfd     int // socket file descriptor
 	localAddr  net.Addr
 	remoteAddr net.Addr
 	in         []byte
@@ -38,7 +37,6 @@ type stdudpconn struct {
 
 func (c *stdudpconn) Context() interface{}       { return nil }
 func (c *stdudpconn) SetContext(ctx interface{}) {}
-func (c *stdudpconn) AddrIndex() int             { return c.addrIndex }
 func (c *stdudpconn) LocalAddr() net.Addr        { return c.localAddr }
 func (c *stdudpconn) RemoteAddr() net.Addr       { return c.remoteAddr }
 func (c *stdudpconn) Wake()                      {}
@@ -51,7 +49,7 @@ type stdloop struct {
 
 type stdconn struct {
 	addrIndex  int
-	sockfd     int              // socket file descriptor
+	sockfd     int // socket file descriptor
 	localAddr  net.Addr
 	remoteAddr net.Addr
 	conn       net.Conn    // original connection
@@ -198,7 +196,7 @@ func stdlistenerRun(s *stdserver, ln *listener, fd int) {
 			}
 			l := s.loops[int(atomic.AddUintptr(&s.accepted, 1))%len(s.loops)]
 			l.ch <- &stdudpconn{
-				sockfd:  fd,
+				sockfd:     fd,
 				localAddr:  ln.lnaddr,
 				remoteAddr: addr,
 				in:         append([]byte{}, packet[:n]...),

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -28,15 +28,13 @@ type conn struct {
 	opened     bool             // connection opened event fired
 	action     Action           // next user action
 	ctx        interface{}      // user-defined context
-	addrIndex  int              // index of listening address
-	localAddr  net.Addr         // local addre
-	remoteAddr net.Addr         // remote addr
+	localAddr  net.Addr         // local address
+	remoteAddr net.Addr         // remote address
 	loop       *loop            // connected loop
 }
 
 func (c *conn) Context() interface{}       { return c.ctx }
 func (c *conn) SetContext(ctx interface{}) { c.ctx = ctx }
-func (c *conn) AddrIndex() int             { return c.addrIndex }
 func (c *conn) LocalAddr() net.Addr        { return c.localAddr }
 func (c *conn) RemoteAddr() net.Addr       { return c.remoteAddr }
 func (c *conn) Wake() {

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	reuseport "github.com/kavu/go_reuseport"
-	"github.com/panjf2000/evio/internal"
+	"github.com/tidwall/evio/internal"
 )
 
 type conn struct {

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -9,7 +9,6 @@ package evio
 import (
 	"io"
 	"net"
-	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -17,7 +16,7 @@ import (
 	"time"
 
 	reuseport "github.com/kavu/go_reuseport"
-	"github.com/tidwall/evio/internal"
+	"github.com/panjf2000/evio/internal"
 )
 
 type conn struct {
@@ -95,8 +94,8 @@ func serve(events Events, listeners []*listener) error {
 	s.cond = sync.NewCond(&sync.Mutex{})
 	s.balance = events.LoadBalance
 	s.tch = make(chan time.Duration)
-	s.fdlns = make(map[int]*listener, len(listeners))
 
+	s.fdlns = make(map[int]*listener, len(listeners))
 	for _, ln := range listeners {
 		s.fdlns[ln.fd] = ln
 	}
@@ -478,47 +477,6 @@ func (c *detachedConn) Write(p []byte) (n int, err error) {
 		p = p[nn:]
 	}
 	return n, nil
-}
-
-func (ln *listener) close() {
-	if ln.fd != 0 {
-		syscall.Close(ln.fd)
-	}
-	if ln.f != nil {
-		ln.f.Close()
-	}
-	if ln.ln != nil {
-		ln.ln.Close()
-	}
-	if ln.pconn != nil {
-		ln.pconn.Close()
-	}
-	if ln.network == "unix" {
-		os.RemoveAll(ln.addr)
-	}
-}
-
-// system takes the net listener and detaches it from it's parent
-// event loop, grabs the file descriptor, and makes it non-blocking.
-func (ln *listener) system() error {
-	var err error
-	switch netln := ln.ln.(type) {
-	case nil:
-		switch pconn := ln.pconn.(type) {
-		case *net.UDPConn:
-			ln.f, err = pconn.File()
-		}
-	case *net.TCPListener:
-		ln.f, err = netln.File()
-	case *net.UnixListener:
-		ln.f, err = netln.File()
-	}
-	if err != nil {
-		ln.close()
-		return err
-	}
-	ln.fd = int(ln.f.Fd())
-	return syscall.SetNonblock(ln.fd, true)
 }
 
 func reuseportListenPacket(proto, addr string) (l net.PacketConn, err error) {

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -29,7 +29,7 @@ type conn struct {
 	opened     bool             // connection opened event fired
 	action     Action           // next user action
 	ctx        interface{}      // user-defined context
-	addrIndex  int				// index of listening address
+	addrIndex  int              // index of listening address
 	localAddr  net.Addr         // local addre
 	remoteAddr net.Addr         // remote addr
 	loop       *loop            // connected loop


### PR DESCRIPTION
Code changes had been tested locally, including unit-test and benchmark-test.