### PR TITLE
Make sure it only do the signalShutdown once

### DIFF
--- a/evio.go
+++ b/evio.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -226,6 +227,47 @@ type listener struct {
 	fd      int
 	network string
 	addr    string
+}
+
+func (ln *listener) close() {
+	if ln.fd != 0 {
+		syscall.Close(ln.fd)
+	}
+	if ln.f != nil {
+		ln.f.Close()
+	}
+	if ln.ln != nil {
+		ln.ln.Close()
+	}
+	if ln.pconn != nil {
+		ln.pconn.Close()
+	}
+	if ln.network == "unix" {
+		os.RemoveAll(ln.addr)
+	}
+}
+
+// system takes the net listener and detaches it from it's parent
+// event loop, grabs the file descriptor, and makes it non-blocking.
+func (ln *listener) system() error {
+	var err error
+	switch netln := ln.ln.(type) {
+	case nil:
+		switch pconn := ln.pconn.(type) {
+		case *net.UDPConn:
+			ln.f, err = pconn.File()
+		}
+	case *net.TCPListener:
+		ln.f, err = netln.File()
+	case *net.UnixListener:
+		ln.f, err = netln.File()
+	}
+	if err != nil {
+		ln.close()
+		return err
+	}
+	ln.fd = int(ln.f.Fd())
+	return syscall.SetNonblock(ln.fd, true)
 }
 
 type addrOpts struct {

--- a/evio.go
+++ b/evio.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -227,47 +226,6 @@ type listener struct {
 	fd      int
 	network string
 	addr    string
-}
-
-func (ln *listener) close() {
-	if ln.fd != 0 {
-		syscall.Close(ln.fd)
-	}
-	if ln.f != nil {
-		ln.f.Close()
-	}
-	if ln.ln != nil {
-		ln.ln.Close()
-	}
-	if ln.pconn != nil {
-		ln.pconn.Close()
-	}
-	if ln.network == "unix" {
-		os.RemoveAll(ln.addr)
-	}
-}
-
-// system takes the net listener and detaches it from it's parent
-// event loop, grabs the file descriptor, and makes it non-blocking.
-func (ln *listener) system() error {
-	var err error
-	switch netln := ln.ln.(type) {
-	case nil:
-		switch pconn := ln.pconn.(type) {
-		case *net.UDPConn:
-			ln.f, err = pconn.File()
-		}
-	case *net.TCPListener:
-		ln.f, err = netln.File()
-	case *net.UnixListener:
-		ln.f, err = netln.File()
-	}
-	if err != nil {
-		ln.close()
-		return err
-	}
-	ln.fd = int(ln.f.Fd())
-	return syscall.SetNonblock(ln.fd, true)
 }
 
 type addrOpts struct {

--- a/evio_std.go
+++ b/evio_std.go
@@ -26,6 +26,7 @@ type stdserver struct {
 	cond     *sync.Cond     // shutdown signaler
 	serr     error          // signal error
 	accepted uintptr        // accept counter
+	once     sync.Once      // make sure it only signalShutdown once
 }
 
 type stdudpconn struct {
@@ -92,10 +93,12 @@ func (s *stdserver) waitForShutdown() error {
 
 // signalShutdown signals a shutdown an begins server closing
 func (s *stdserver) signalShutdown(err error) {
-	s.cond.L.Lock()
-	s.serr = err
-	s.cond.Signal()
-	s.cond.L.Unlock()
+	s.once.Do(func() {
+		s.cond.L.Lock()
+		s.serr = err
+		s.cond.Signal()
+		s.cond.L.Unlock()
+	})
 }
 
 func stdserve(events Events, listeners []*listener) error {

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -9,6 +9,7 @@ package evio
 import (
 	"io"
 	"net"
+	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -443,6 +443,9 @@ func loopRead(s *server, l *loop, c *conn) error {
 	}
 	if len(c.out) != 0 || c.action != None {
 		l.poll.ModReadWrite(c.fd)
+		if len(c.out) > 0 && None == c.action {
+			return loopWrite(s, l, c)
+		}
 	}
 	return nil
 }

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -9,7 +9,6 @@ package evio
 import (
 	"io"
 	"net"
-	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -482,47 +481,6 @@ func (c *detachedConn) Write(p []byte) (n int, err error) {
 		p = p[nn:]
 	}
 	return n, nil
-}
-
-func (ln *listener) close() {
-	if ln.fd != 0 {
-		syscall.Close(ln.fd)
-	}
-	if ln.f != nil {
-		ln.f.Close()
-	}
-	if ln.ln != nil {
-		ln.ln.Close()
-	}
-	if ln.pconn != nil {
-		ln.pconn.Close()
-	}
-	if ln.network == "unix" {
-		os.RemoveAll(ln.addr)
-	}
-}
-
-// system takes the net listener and detaches it from it's parent
-// event loop, grabs the file descriptor, and makes it non-blocking.
-func (ln *listener) system() error {
-	var err error
-	switch netln := ln.ln.(type) {
-	case nil:
-		switch pconn := ln.pconn.(type) {
-		case *net.UDPConn:
-			ln.f, err = pconn.File()
-		}
-	case *net.TCPListener:
-		ln.f, err = netln.File()
-	case *net.UnixListener:
-		ln.f, err = netln.File()
-	}
-	if err != nil {
-		ln.close()
-		return err
-	}
-	ln.fd = int(ln.f.Fd())
-	return syscall.SetNonblock(ln.fd, true)
 }
 
 func reuseportListenPacket(proto, addr string) (l net.PacketConn, err error) {

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -443,9 +443,6 @@ func loopRead(s *server, l *loop, c *conn) error {
 	}
 	if len(c.out) != 0 || c.action != None {
 		l.poll.ModReadWrite(c.fd)
-		if len(c.out) > 0 && None == c.action {
-			return loopWrite(s, l, c)
-		}
 	}
 	return nil
 }
@@ -487,6 +484,47 @@ func (c *detachedConn) Write(p []byte) (n int, err error) {
 		p = p[nn:]
 	}
 	return n, nil
+}
+
+func (ln *listener) close() {
+	if ln.fd != 0 {
+		syscall.Close(ln.fd)
+	}
+	if ln.f != nil {
+		ln.f.Close()
+	}
+	if ln.ln != nil {
+		ln.ln.Close()
+	}
+	if ln.pconn != nil {
+		ln.pconn.Close()
+	}
+	if ln.network == "unix" {
+		os.RemoveAll(ln.addr)
+	}
+}
+
+// system takes the net listener and detaches it from it's parent
+// event loop, grabs the file descriptor, and makes it non-blocking.
+func (ln *listener) system() error {
+	var err error
+	switch netln := ln.ln.(type) {
+	case nil:
+		switch pconn := ln.pconn.(type) {
+		case *net.UDPConn:
+			ln.f, err = pconn.File()
+		}
+	case *net.TCPListener:
+		ln.f, err = netln.File()
+	case *net.UnixListener:
+		ln.f, err = netln.File()
+	}
+	if err != nil {
+		ln.close()
+		return err
+	}
+	ln.fd = int(ln.f.Fd())
+	return syscall.SetNonblock(ln.fd, true)
 }
 
 func reuseportListenPacket(proto, addr string) (l net.PacketConn, err error) {


### PR DESCRIPTION
Use `sync.Once` to make sure it would only call `signalShutdow` once when trying to shutdown `evio` cuz I found that it would call this function as many times as the number of loops and listeners, which is the redundant cost.