### PR TITLE
Reduce at least one syscall.EPOLLOUT event in every connection

### DIFF
--- a/evio_unix.go
+++ b/evio_unix.go
@@ -441,7 +441,7 @@ func loopRead(s *server, l *loop, c *conn) error {
 	}
 	if len(c.out) != 0 || c.action != None {
 		l.poll.ModReadWrite(c.fd)
-		if len(c.out) > 0 && None == c.action {
+		if len(s.loops) != 1 && len(c.out) > 0 && None == c.action {
 			return loopWrite(s, l, c)
 		}
 	}

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -441,7 +441,7 @@ func loopRead(s *server, l *loop, c *conn) error {
 	}
 	if len(c.out) != 0 || c.action != None {
 		l.poll.ModReadWrite(c.fd)
-		if len(s.loops) != 1 && len(c.out) > 0 && None == c.action {
+		if len(s.loops) > 1 && len(c.out) > 0 && None == c.action {
 			return loopWrite(s, l, c)
 		}
 	}

--- a/evio_unix.go
+++ b/evio_unix.go
@@ -441,6 +441,9 @@ func loopRead(s *server, l *loop, c *conn) error {
 	}
 	if len(c.out) != 0 || c.action != None {
 		l.poll.ModReadWrite(c.fd)
+		if len(c.out) > 0 && None == c.action {
+			return loopWrite(s, l, c)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Reduce at least one syscall.EPOLLOUT event in every connection, enhancing a bit of performance. 

**Benchmark between this branch and master:**

![bench2](https://user-images.githubusercontent.com/7496278/56559948-a9a34600-65d5-11e9-97b5-e92a465f6001.png)
![bench3](https://user-images.githubusercontent.com/7496278/56559955-b031bd80-65d5-11e9-9401-e9a41db860d0.png)
![bench4](https://user-images.githubusercontent.com/7496278/56559962-b32cae00-65d5-11e9-845f-0bfbccd7be43.png)

Benchmark test in Amazon EC2:
```
c5.2xlarge (8 Virtual CPUs, 16.0 GiB Memory, 120 GiB SSD (EBS) Storage)
gcc version 7.2.1 20170915 (Red Hat 7.2.1-2) (GCC)
```