### PR TITLE
Fix Poll.Trigger byte order bug under linux

### DIFF
--- a/internal/internal_linux.go
+++ b/internal/internal_linux.go
@@ -6,6 +6,7 @@ package internal
 
 import (
 	"syscall"
+	"unsafe"
 )
 
 // Poll ...
@@ -44,7 +45,8 @@ func (p *Poll) Close() error {
 // Trigger ...
 func (p *Poll) Trigger(note interface{}) error {
 	p.notes.Add(note)
-	_, err := syscall.Write(p.wfd, []byte{0, 0, 0, 0, 0, 0, 0, 1})
+	var x uint64 = 1
+	_, err := syscall.Write(p.wfd, (*(*[8]byte)(unsafe.Pointer(&x)))[:])
 	return err
 }
 


### PR DESCRIPTION
See http://man7.org/linux/man-pages/man2/eventfd.2.html
Bytes written into an eventfd object should have the same endianness as the host machine. 
Here I assume Poll.Trigger tends to incr by 1, not 1 << 56.