### PR TITLE
Fix http server example - parsing request path and query

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -167,11 +167,11 @@ func parsereq(data []byte, req *request) (leftover []byte, err error) {
 			req.method = sdata[s:i]
 			for i, s = i+1, i+1; i < len(sdata); i++ {
 				if sdata[i] == '?' && q == -1 {
-					q = i - s
+					q = i
 				} else if sdata[i] == ' ' {
 					if q != -1 {
 						req.path = sdata[s:q]
-						req.query = req.path[q+1 : i]
+						req.query = sdata[q+1 : i]
 					} else {
 						req.path = sdata[s:i]
 					}


### PR DESCRIPTION
When I run "go run main.go --noparse=false" and made request like "curl localhost:8080/aaa?dddd=ddd" I got panic:

> panic: runtime error: slice bounds out of range [:17] with length 0
> goroutine 6 [running]:
> main.parsereq(0xc00001e240, 0x5a, 0x60, 0xc000059a78, 0x900100004367cc, 0x0, 0x8, 0x417e5e, 0xc000059a38)
>	/home/ewgra/dev/go/src/github.com/tidwall/evio/examples/http-server/main.go:175 +0x773

This PR fixes http server example - parsing request path and query.