### PR TITLE
Fix typo in event.Tick example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The `Tick` event fires ticks at a specified interval.
 The first tick fires immediately after the `Serving` events.
 
 ```go
-events.Tick = func() (delay time.Duration, action Action){
+events.Tick = func() (delay time.Duration, action evio.Action){
 	log.Printf("tick")
 	delay = time.Second
 	return


### PR DESCRIPTION
Fix typo in `event.Tick` example in README

```diff
-events.Tick = func() (delay time.Duration, action Action){
+events.Tick = func() (delay time.Duration, action evio.Action){
        log.Printf("tick")
        delay = time.Second
        return